### PR TITLE
fix: build on latest nightly (1.95.0-nightly)

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -2,7 +2,6 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![feature(portable_simd)]
-#![feature(stdarch_x86_avx512)]
 
 use std::arch::x86_64::*;
 use std::mem;

--- a/examples/_internal/dasm.rs
+++ b/examples/_internal/dasm.rs
@@ -1,4 +1,3 @@
-#![feature(stdarch_x86_avx512)]
 #![feature(portable_simd)]
 
 use std::arch::x86_64::*;

--- a/examples/_internal/practrand.rs
+++ b/examples/_internal/practrand.rs
@@ -3,7 +3,6 @@
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 #![feature(portable_simd)]
-#![feature(stdarch_x86_avx512)]
 
 use std::io::{ErrorKind, Write};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,6 @@
 //!
 //! There is also some inline assembly used, where the C-style intrinsics haven't been exposed as Rust APIs in `std::arch`.
 
-// stdarch_x86_avx512 feature is required for some of the AVX512 intrinsisc
-#![cfg_attr(
-    all(target_arch = "x86_64", target_feature = "avx512f", target_feature = "avx512dq"),
-    feature(stdarch_x86_avx512)
-)]
 #![feature(portable_simd)]
 
 pub mod portable;

--- a/src/portable/mod.rs
+++ b/src/portable/mod.rs
@@ -2,7 +2,7 @@ use std::{
     fmt::Debug,
     mem,
     ops::{BitOr, Shl, Shr, Sub},
-    simd::{LaneCount, Simd, SimdElement, SupportedLaneCount},
+    simd::{Simd, SimdElement},
 };
 
 pub use simdrand::*;
@@ -19,8 +19,6 @@ mod xoshiro256plusx8;
 
 #[inline(always)]
 fn read_u64_into_vec<const N: usize>(src: &[u8]) -> Simd<u64, N>
-where
-    LaneCount<N>: SupportedLaneCount,
 {
     const SIZE: usize = mem::size_of::<u64>();
     assert!(src.len() == SIZE * N);
@@ -39,7 +37,6 @@ where
 fn rotate_left<T, const N: usize>(x: Simd<T, N>, k: T) -> Simd<T, N>
 where
     T: SimdElement + Sub<T, Output = T>,
-    LaneCount<N>: SupportedLaneCount,
     usize: TryInto<T>,
     <usize as TryInto<T>>::Error: Debug,
     Simd<T, N>: Shl<Simd<T, N>, Output = Simd<T, N>>,


### PR DESCRIPTION
- stdarch_x86_avx512 is standardized: https://github.com/rust-lang/stdarch/pull/1819
- LaneCount/SupportedLaneCount was removed: https://github.com/rust-lang/portable-simd/pull/485