### PR TITLE
chore: get rid of unnecessary transmutes

### DIFF
--- a/src/specific/avx2/mod.rs
+++ b/src/specific/avx2/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    arch::x86_64::*,
-    mem::{self, transmute},
-};
+use std::{arch::x86_64::*, mem};
 
 pub use shishua::*;
 pub use simdrand::*;
@@ -21,10 +18,10 @@ fn read_u64_into_vec(src: &[u8]) -> __m256i {
     assert!(src.len() == SIZE * 4);
     unsafe {
         _mm256_set_epi64x(
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 0)..(SIZE * 1)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 1)..(SIZE * 2)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 2)..(SIZE * 3)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 3)..(SIZE * 4)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 0)..(SIZE * 1)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 1)..(SIZE * 2)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 2)..(SIZE * 3)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 3)..(SIZE * 4)].try_into().unwrap())),
         )
     }
 }

--- a/src/specific/avx2/shishua.rs
+++ b/src/specific/avx2/shishua.rs
@@ -233,28 +233,28 @@ impl RawState {
         let mut buf: [u8; 128 * STEPS] = [0; 128 * STEPS];
 
         self.state[0] = _mm256_set_epi64x(
-            mem::transmute::<u64, i64>(PHI[3]),
-            mem::transmute::<u64, i64>(PHI[2]) ^ seed[1] as i64,
-            mem::transmute::<u64, i64>(PHI[1]),
-            mem::transmute::<u64, i64>(PHI[0]) ^ seed[0] as i64,
+            u64::cast_signed(PHI[3]),
+            u64::cast_signed(PHI[2]) ^ seed[1] as i64,
+            u64::cast_signed(PHI[1]),
+            u64::cast_signed(PHI[0]) ^ seed[0] as i64,
         );
         self.state[1] = _mm256_set_epi64x(
-            mem::transmute::<u64, i64>(PHI[7]),
-            mem::transmute::<u64, i64>(PHI[6]) ^ seed[3] as i64,
-            mem::transmute::<u64, i64>(PHI[5]),
-            mem::transmute::<u64, i64>(PHI[4]) ^ seed[2] as i64,
+            u64::cast_signed(PHI[7]),
+            u64::cast_signed(PHI[6]) ^ seed[3] as i64,
+            u64::cast_signed(PHI[5]),
+            u64::cast_signed(PHI[4]) ^ seed[2] as i64,
         );
         self.state[2] = _mm256_set_epi64x(
-            mem::transmute::<u64, i64>(PHI[11]),
-            mem::transmute::<u64, i64>(PHI[10]) ^ seed[3] as i64,
-            mem::transmute::<u64, i64>(PHI[9]),
-            mem::transmute::<u64, i64>(PHI[8]) ^ seed[2] as i64,
+            u64::cast_signed(PHI[11]),
+            u64::cast_signed(PHI[10]) ^ seed[3] as i64,
+            u64::cast_signed(PHI[9]),
+            u64::cast_signed(PHI[8]) ^ seed[2] as i64,
         );
         self.state[3] = _mm256_set_epi64x(
-            mem::transmute::<u64, i64>(PHI[15]),
-            mem::transmute::<u64, i64>(PHI[14]) ^ seed[1] as i64,
-            mem::transmute::<u64, i64>(PHI[13]),
-            mem::transmute::<u64, i64>(PHI[12]) ^ seed[0] as i64,
+            u64::cast_signed(PHI[15]),
+            u64::cast_signed(PHI[14]) ^ seed[1] as i64,
+            u64::cast_signed(PHI[13]),
+            u64::cast_signed(PHI[12]) ^ seed[0] as i64,
         );
         for _ in 0..ROUNDS {
             Self::prng_gen(self, &mut buf[..]);

--- a/src/specific/avx512/mod.rs
+++ b/src/specific/avx512/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    arch::x86_64::*,
-    mem::{self, transmute},
-};
+use std::{arch::x86_64::*, mem};
 
 // pub use shishua::*;
 pub use simdrand::*;
@@ -21,14 +18,14 @@ fn read_u64_into_vec(src: &[u8]) -> __m512i {
     assert!(src.len() == SIZE * 8);
     unsafe {
         _mm512_set_epi64(
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 0)..(SIZE * 1)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 1)..(SIZE * 2)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 2)..(SIZE * 3)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 3)..(SIZE * 4)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 4)..(SIZE * 5)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 5)..(SIZE * 6)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 6)..(SIZE * 7)].try_into().unwrap())),
-            transmute::<_, i64>(u64::from_le_bytes(src[(SIZE * 7)..(SIZE * 8)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 0)..(SIZE * 1)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 1)..(SIZE * 2)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 2)..(SIZE * 3)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 3)..(SIZE * 4)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 4)..(SIZE * 5)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 5)..(SIZE * 6)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 6)..(SIZE * 7)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 7)..(SIZE * 8)].try_into().unwrap())),
         )
     }
 }


### PR DESCRIPTION
from cargo fix