### PR TITLE
slightly improve top benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ outbin := ${bindir}/profile
 TARGET := x86_64-unknown-linux-gnu
 RUSTFLAGS_AVX512 := -C target-feature=+avx2,+avx512f,+avx512dq,+avx512vl
 CARGO_NIGHTLY := cargo +nightly
+BENCH_CPU ?= 31
 
 all: run
 
@@ -28,7 +29,10 @@ bench:
 	$(CARGO_NIGHTLY) bench --features portable -- "$(F)" --verbose
 
 bench-top:
-	$(CARGO_NIGHTLY) bench --features portable -- "Top" --warm-up-time 5 --measurement-time 10 --sample-size 200
+	@test "$$(cat /sys/devices/system/cpu/cpu$(BENCH_CPU)/cpufreq/scaling_governor)" = performance || \
+		(echo "cpu$(BENCH_CPU) scaling governor must be performance" >&2; exit 1)
+	taskset --cpu-list $(BENCH_CPU) env RUSTFLAGS="$(RUSTFLAGS_AVX512)" \
+		$(CARGO_NIGHTLY) bench --features portable -- "Top" --warm-up-time 5 --measurement-time 10 --sample-size 200
 
 stat: build
 	perf stat -d -d -d $(outbin)

--- a/README.md
+++ b/README.md
@@ -75,21 +75,17 @@ decides what to do with the vectors, whereas with AVX512 specific ones in the `s
 
 ```text
 Top/rand/Xoshiro256+
-                        time:   [3.2356 ns 3.2367 ns 3.2379 ns]
-                        thrpt:  [2.4707 Gelem/s 2.4717 Gelem/s 2.4725 Gelem/s]
-                        thrpt:  [18.408 GiB/s 18.415 GiB/s 18.422 GiB/s]
-Top/frand
-                        time:   [2.5572 ns 2.5580 ns 2.5590 ns]
-                        thrpt:  [3.1262 Gelem/s 3.1275 Gelem/s 3.1285 Gelem/s]
-                        thrpt:  [23.292 GiB/s 23.301 GiB/s 23.309 GiB/s]
+                        time:   [24.963 ns 24.964 ns 24.965 ns]
+                        thrpt:  [2.5636 Gelem/s 2.5637 Gelem/s 2.5638 Gelem/s]
+                        thrpt:  [19.100 GiB/s 19.101 GiB/s 19.102 GiB/s]
 Top/simd_rand/Portable/Xoshiro256+X8
-                        time:   [1.0661 ns 1.0663 ns 1.0665 ns]
-                        thrpt:  [7.5013 Gelem/s 7.5029 Gelem/s 7.5043 Gelem/s]
-                        thrpt:  [55.889 GiB/s 55.901 GiB/s 55.911 GiB/s]
+                        time:   [6.9966 ns 6.9975 ns 6.9983 ns]
+                        thrpt:  [9.1451 Gelem/s 9.1462 Gelem/s 9.1473 Gelem/s]
+                        thrpt:  [68.136 GiB/s 68.144 GiB/s 68.152 GiB/s]
 Top/simd_rand/Specific/Xoshiro256+X8
-                        time:   [1.0653 ns 1.0655 ns 1.0658 ns]
-                        thrpt:  [7.5058 Gelem/s 7.5081 Gelem/s 7.5097 Gelem/s]
-                        thrpt:  [55.922 GiB/s 55.939 GiB/s 55.952 GiB/s]
+                        time:   [6.9453 ns 6.9455 ns 6.9457 ns]
+                        thrpt:  [9.2144 Gelem/s 9.2147 Gelem/s 9.2149 Gelem/s]
+                        thrpt:  [68.652 GiB/s 68.655 GiB/s 68.657 GiB/s]
 ```
 
 ## Safety

--- a/benches/top/mod.rs
+++ b/benches/top/mod.rs
@@ -11,70 +11,45 @@ use simd_rand::specific;
 use std::arch::x86_64::*;
 use std::hint::black_box;
 
-const SEED: u64 = 0x0DDB1A5E5BAD5EEDu64;
-
-#[inline(always)]
-fn execute_rand<RNG: RngCore>(rng: &mut RNG, data: &mut u64x8) {
-    for i in 0..8 {
-        data[i] = rng.next_u64();
-    }
-}
-
-#[inline(always)]
-fn execute_vectorized_portable<RNG: SimdRandX8>(rng: &mut RNG, data: &mut u64x8) {
-    *data = rng.next_u64x8();
-}
-
-#[cfg(all(
-    feature = "specific",
-    target_arch = "x86_64",
-    target_feature = "avx512f",
-    target_feature = "avx512dq",
-    target_feature = "avx512vl"
-))]
-#[inline(always)]
-fn execute_vectorized_specific<RNG: specific::avx512::SimdRand>(rng: &mut RNG, data: &mut __m512i) {
-    *data = rng.next_m512i();
-}
-
 pub fn add_top_benchmark<M: Measurement, const ITERATIONS: usize>(c: &mut Criterion<M>) {
     let mut group = c.benchmark_group("Top");
 
     group.throughput(Throughput::ElementsAndBytes {
-        elements: 8,
-        bytes: mem::size_of::<u64x8>() as u64,
+        elements: (ITERATIONS * 8) as u64,
+        bytes: (ITERATIONS * mem::size_of::<u64x8>()) as u64,
     });
     group.noise_threshold(0.03);
 
+    let mut rng = rand::rng();
+    let init = rng.next_u64();
+
     group.bench_function("rand/Xoshiro256+", |b| {
-        let mut rng = Xoshiro256Plus::seed_from_u64(SEED);
-        let mut data = u64x8::default();
+        let mut rng = Xoshiro256Plus::seed_from_u64(init);
 
         b.iter(|| {
-            execute_rand(&mut rng, &mut data);
-            black_box(&data);
-        });
-    });
+            let mut data = u64x8::splat(init);
 
-    group.bench_function("frand", |b| {
-        let mut rng = Rand::with_seed(SEED);
-        let mut data = u64x8::default();
-
-        b.iter(|| {
-            for i in 0..8 {
-                data[i] = black_box(rng.r#gen::<u64>());
+            for _ in 0..ITERATIONS {
+                for i in 0..8 {
+                    data[i] = rng.next_u64();
+                }
             }
-            black_box(&data);
+
+            data
         });
     });
 
     group.bench_function("simd_rand/Portable/Xoshiro256+X8", |b| {
-        let mut rng = Xoshiro256PlusX8::seed_from_u64(SEED);
-        let mut data = u64x8::default();
+        let mut rng = Xoshiro256PlusX8::seed_from_u64(init);
 
         b.iter(|| {
-            execute_vectorized_portable(&mut rng, &mut data);
-            black_box(&data);
+            let mut data = u64x8::splat(init);
+
+            for _ in 0..ITERATIONS {
+                data = rng.next_u64x8();
+            }
+
+            data
         });
     });
 
@@ -85,13 +60,17 @@ pub fn add_top_benchmark<M: Measurement, const ITERATIONS: usize>(c: &mut Criter
         target_feature = "avx512dq",
         target_feature = "avx512vl"
     ))]
-    group.bench_function("simd_rand/Specific/Xoshiro256+X8", |b| unsafe {
-        let mut rng = specific::avx512::Xoshiro256PlusX8::seed_from_u64(SEED);
-        let mut data: __m512i = _mm512_setzero_si512();
+    group.bench_function("simd_rand/Specific/Xoshiro256+X8", |b| {
+        let mut rng = specific::avx512::Xoshiro256PlusX8::seed_from_u64(init);
 
         b.iter(|| {
-            execute_vectorized_specific(&mut rng, &mut data);
-            black_box(&data);
+            let mut data = unsafe { _mm512_set1_epi64(init as i64) };
+
+            for _ in 0..ITERATIONS {
+                data = specific::avx512::SimdRand::next_m512i(&mut rng);
+            }
+
+            data
         });
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,21 +72,17 @@
 //!
 //! ```ignore
 //! Top/rand/Xoshiro256+
-//!                         time:   [3.2356 ns 3.2367 ns 3.2379 ns]
-//!                         thrpt:  [2.4707 Gelem/s 2.4717 Gelem/s 2.4725 Gelem/s]
-//!                         thrpt:  [18.408 GiB/s 18.415 GiB/s 18.422 GiB/s]
-//! Top/frand
-//!                         time:   [2.5572 ns 2.5580 ns 2.5590 ns]
-//!                         thrpt:  [3.1262 Gelem/s 3.1275 Gelem/s 3.1285 Gelem/s]
-//!                         thrpt:  [23.292 GiB/s 23.301 GiB/s 23.309 GiB/s]
+//!                         time:   [24.963 ns 24.964 ns 24.965 ns]
+//!                         thrpt:  [2.5636 Gelem/s 2.5637 Gelem/s 2.5638 Gelem/s]
+//!                         thrpt:  [19.100 GiB/s 19.101 GiB/s 19.102 GiB/s]
 //! Top/simd_rand/Portable/Xoshiro256+X8
-//!                         time:   [1.0661 ns 1.0663 ns 1.0665 ns]
-//!                         thrpt:  [7.5013 Gelem/s 7.5029 Gelem/s 7.5043 Gelem/s]
-//!                         thrpt:  [55.889 GiB/s 55.901 GiB/s 55.911 GiB/s]
+//!                         time:   [6.9966 ns 6.9975 ns 6.9983 ns]
+//!                         thrpt:  [9.1451 Gelem/s 9.1462 Gelem/s 9.1473 Gelem/s]
+//!                         thrpt:  [68.136 GiB/s 68.144 GiB/s 68.152 GiB/s]
 //! Top/simd_rand/Specific/Xoshiro256+X8
-//!                         time:   [1.0653 ns 1.0655 ns 1.0658 ns]
-//!                         thrpt:  [7.5058 Gelem/s 7.5081 Gelem/s 7.5097 Gelem/s]
-//!                         thrpt:  [55.922 GiB/s 55.939 GiB/s 55.952 GiB/s]
+//!                         time:   [6.9453 ns 6.9455 ns 6.9457 ns]
+//!                         thrpt:  [9.2144 Gelem/s 9.2147 Gelem/s 9.2149 Gelem/s]
+//!                         thrpt:  [68.652 GiB/s 68.655 GiB/s 68.657 GiB/s]
 //! ```
 //!
 //! ## Safety


### PR DESCRIPTION
- slightly improve top benchmark stability by dedicating a physical core to these runs on my machine
- some tweaks to the top benchmark code in an effort to further reduce outliers and get more realistic output (more work done per iteration)
- remove scalar frand due to the difficulty of getting representative numbers from it (will add it back later)
  - had an extra black_box that penalized it
  - just removing the black_box would eliminate a bunch of code entirely leading to insane numbers
  - adding some accumulative work to avoid dead code elimination still let LLVM vectorize it for this simple microbenchmark code