### PR TITLE
fix seed lane ordering issue in specific avx implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
             toolchain: nightly
             rustflags: ""
             cargo-args: "--no-default-features --features portable"
+          - name: nightly-portable-specific-avx2
+            toolchain: nightly
+            rustflags: "-C target-feature=+avx2"
+            cargo-args: "--features portable"
     name: test (${{ matrix.name }})
     env:
       CARGO_PROFILE_RELEASE_LTO: "false"

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ lint:
 
 test:
 	cargo nextest run && cargo nextest run --release
+	RUSTFLAGS="$(RUSTFLAGS_AVX512)" $(CARGO_NIGHTLY) nextest run --features portable --target $(TARGET)
+	RUSTFLAGS="$(RUSTFLAGS_AVX512)" $(CARGO_NIGHTLY) nextest run --release --features portable --target $(TARGET)
 
 test-miri:
 	$(CARGO_NIGHTLY) miri test -p simd_rand --no-default-features --features portable --lib

--- a/src/specific/avx2/mod.rs
+++ b/src/specific/avx2/mod.rs
@@ -21,10 +21,10 @@ fn read_u64_into_vec(src: &[u8]) -> __m256i {
     assert!(src.len() == SIZE * 4);
     unsafe {
         _mm256_set_epi64x(
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 0)..(SIZE * 1)].try_into().unwrap())),
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 1)..(SIZE * 2)].try_into().unwrap())),
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 2)..(SIZE * 3)].try_into().unwrap())),
             u64::cast_signed(u64::from_le_bytes(src[(SIZE * 3)..(SIZE * 4)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 2)..(SIZE * 3)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 1)..(SIZE * 2)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 0)..(SIZE * 1)].try_into().unwrap())),
         )
     }
 }
@@ -44,5 +44,36 @@ fn rotate_left<const K: i32>(x: __m256i) -> __m256i {
         let left = _mm256_sll_epi64(x, _mm_cvtsi32_si128(K));
         let right = _mm256_srl_epi64(x, _mm_cvtsi32_si128(64 - K));
         _mm256_or_si256(left, right)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::arch::x86_64::{__m256i, _mm256_store_si256};
+
+    use super::{read_u64_into_vec, vecs::U64x4};
+
+    #[test]
+    fn read_u64_into_vec_preserves_lane_order() {
+        let expected: [u64; 4] = [
+            0x0123_4567_89AB_CDEFu64,
+            0x1112_1314_1516_1718u64,
+            0x2122_2324_2526_2728u64,
+            0x3132_3334_3536_3738u64,
+        ];
+        let mut src = [0u8; 32];
+
+        for (index, value) in expected.into_iter().enumerate() {
+            src[(index * 8)..((index + 1) * 8)].copy_from_slice(&value.to_le_bytes());
+        }
+
+        let vector = read_u64_into_vec(&src);
+        let mut actual = U64x4::default();
+
+        unsafe {
+            _mm256_store_si256(core::ptr::from_mut(&mut actual).cast::<__m256i>(), vector);
+        }
+
+        assert_eq!(&*actual, &expected);
     }
 }

--- a/src/specific/avx512/mod.rs
+++ b/src/specific/avx512/mod.rs
@@ -21,14 +21,49 @@ fn read_u64_into_vec(src: &[u8]) -> __m512i {
     assert!(src.len() == SIZE * 8);
     unsafe {
         _mm512_set_epi64(
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 0)..(SIZE * 1)].try_into().unwrap())),
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 1)..(SIZE * 2)].try_into().unwrap())),
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 2)..(SIZE * 3)].try_into().unwrap())),
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 3)..(SIZE * 4)].try_into().unwrap())),
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 4)..(SIZE * 5)].try_into().unwrap())),
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 5)..(SIZE * 6)].try_into().unwrap())),
-            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 6)..(SIZE * 7)].try_into().unwrap())),
             u64::cast_signed(u64::from_le_bytes(src[(SIZE * 7)..(SIZE * 8)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 6)..(SIZE * 7)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 5)..(SIZE * 6)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 4)..(SIZE * 5)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 3)..(SIZE * 4)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 2)..(SIZE * 3)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 1)..(SIZE * 2)].try_into().unwrap())),
+            u64::cast_signed(u64::from_le_bytes(src[(SIZE * 0)..(SIZE * 1)].try_into().unwrap())),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::arch::x86_64::_mm512_store_epi64;
+
+    use super::{read_u64_into_vec, vecs::U64x8};
+
+    #[test]
+    fn read_u64_into_vec_preserves_lane_order() {
+        let expected: [u64; 8] = [
+            0x0123_4567_89AB_CDEFu64,
+            0x1112_1314_1516_1718u64,
+            0x2122_2324_2526_2728u64,
+            0x3132_3334_3536_3738u64,
+            0x4142_4344_4546_4748u64,
+            0x5152_5354_5556_5758u64,
+            0x6162_6364_6566_6768u64,
+            0x7172_7374_7576_7778u64,
+        ];
+        let mut src = [0u8; 64];
+
+        for (index, value) in expected.into_iter().enumerate() {
+            src[(index * 8)..((index + 1) * 8)].copy_from_slice(&value.to_le_bytes());
+        }
+
+        let vector = read_u64_into_vec(&src);
+        let mut actual = U64x8::default();
+
+        unsafe {
+            _mm512_store_epi64(core::ptr::from_mut(&mut actual).cast::<i64>(), vector);
+        }
+
+        assert_eq!(&*actual, &expected);
     }
 }

--- a/tests/seed_ordering.rs
+++ b/tests/seed_ordering.rs
@@ -13,6 +13,12 @@ fn fill_seed_32(words: &[u64; 4]) -> [u8; 32] {
     seed
 }
 
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx512f",
+    target_feature = "avx512dq",
+    target_feature = "avx512vl"
+))]
 fn fill_seed_64(words: &[u64; 8]) -> [u8; 64] {
     let mut seed = [0u8; 64];
 
@@ -33,6 +39,12 @@ fn fill_seed_128(words: &[u64; 16]) -> [u8; 128] {
     seed
 }
 
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx512f",
+    target_feature = "avx512dq",
+    target_feature = "avx512vl"
+))]
 fn fill_seed_256(words: &[u64; 32]) -> [u8; 256] {
     let mut seed = [0u8; 256];
 

--- a/tests/seed_ordering.rs
+++ b/tests/seed_ordering.rs
@@ -1,0 +1,171 @@
+#![cfg(all(feature = "portable", feature = "specific"))]
+#![cfg_attr(feature = "portable", feature(portable_simd))]
+
+use rand_core::SeedableRng;
+
+fn fill_seed_32(words: &[u64; 4]) -> [u8; 32] {
+    let mut seed = [0u8; 32];
+
+    for (index, word) in words.iter().enumerate() {
+        seed[(index * 8)..((index + 1) * 8)].copy_from_slice(&word.to_le_bytes());
+    }
+
+    seed
+}
+
+fn fill_seed_64(words: &[u64; 8]) -> [u8; 64] {
+    let mut seed = [0u8; 64];
+
+    for (index, word) in words.iter().enumerate() {
+        seed[(index * 8)..((index + 1) * 8)].copy_from_slice(&word.to_le_bytes());
+    }
+
+    seed
+}
+
+fn fill_seed_128(words: &[u64; 16]) -> [u8; 128] {
+    let mut seed = [0u8; 128];
+
+    for (index, word) in words.iter().enumerate() {
+        seed[(index * 8)..((index + 1) * 8)].copy_from_slice(&word.to_le_bytes());
+    }
+
+    seed
+}
+
+fn fill_seed_256(words: &[u64; 32]) -> [u8; 256] {
+    let mut seed = [0u8; 256];
+
+    for (index, word) in words.iter().enumerate() {
+        seed[(index * 8)..((index + 1) * 8)].copy_from_slice(&word.to_le_bytes());
+    }
+
+    seed
+}
+
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+#[test]
+fn avx2_matches_portable_for_asymmetric_seeds() {
+    use simd_rand::portable::{
+        FrandX4 as PortableFrandX4, FrandX4Seed as PortableFrandX4Seed, SimdRandX4,
+        Xoshiro256PlusX4 as PortableXoshiro256PlusX4, Xoshiro256PlusX4Seed as PortableXoshiro256PlusX4Seed,
+    };
+    use simd_rand::specific::avx2::{
+        FrandX4 as SpecificFrandX4, FrandX4Seed as SpecificFrandX4Seed, SimdRand,
+        Xoshiro256PlusX4 as SpecificXoshiro256PlusX4, Xoshiro256PlusX4Seed as SpecificXoshiro256PlusX4Seed,
+    };
+
+    let frand_seed = fill_seed_32(&[
+        0x0123_4567_89AB_CDEF,
+        0x1112_1314_1516_1718,
+        0x2122_2324_2526_2728,
+        0x3132_3334_3536_3738,
+    ]);
+    let mut portable_frand = PortableFrandX4::from_seed(PortableFrandX4Seed::from(frand_seed));
+    let mut specific_frand = SpecificFrandX4::from_seed(SpecificFrandX4Seed::from(frand_seed));
+
+    for _ in 0..3 {
+        assert_eq!(portable_frand.next_u64x4().to_array(), *specific_frand.next_u64x4());
+    }
+
+    let xoshiro_seed = fill_seed_128(&[
+        0x0001_0002_0003_0004,
+        0x0101_0102_0103_0104,
+        0x0201_0202_0203_0204,
+        0x0301_0302_0303_0304,
+        0x1001_1002_1003_1004,
+        0x1101_1102_1103_1104,
+        0x1201_1202_1203_1204,
+        0x1301_1302_1303_1304,
+        0x2001_2002_2003_2004,
+        0x2101_2102_2103_2104,
+        0x2201_2202_2203_2204,
+        0x2301_2302_2303_2304,
+        0x3001_3002_3003_3004,
+        0x3101_3102_3103_3104,
+        0x3201_3202_3203_3204,
+        0x3301_3302_3303_3304,
+    ]);
+    let mut portable_xoshiro = PortableXoshiro256PlusX4::from_seed(PortableXoshiro256PlusX4Seed::from(xoshiro_seed));
+    let mut specific_xoshiro = SpecificXoshiro256PlusX4::from_seed(SpecificXoshiro256PlusX4Seed::from(xoshiro_seed));
+
+    for _ in 0..3 {
+        assert_eq!(portable_xoshiro.next_u64x4().to_array(), *specific_xoshiro.next_u64x4());
+    }
+}
+
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "avx512f",
+    target_feature = "avx512dq",
+    target_feature = "avx512vl"
+))]
+#[test]
+fn avx512_matches_portable_for_asymmetric_seeds() {
+    use simd_rand::portable::{
+        FrandX8 as PortableFrandX8, FrandX8Seed as PortableFrandX8Seed, SimdRandX8,
+        Xoshiro256PlusX8 as PortableXoshiro256PlusX8, Xoshiro256PlusX8Seed as PortableXoshiro256PlusX8Seed,
+    };
+    use simd_rand::specific::avx512::{
+        FrandX8 as SpecificFrandX8, FrandX8Seed as SpecificFrandX8Seed, SimdRand,
+        Xoshiro256PlusX8 as SpecificXoshiro256PlusX8, Xoshiro256PlusX8Seed as SpecificXoshiro256PlusX8Seed,
+    };
+
+    let frand_seed = fill_seed_64(&[
+        0x0123_4567_89AB_CDEF,
+        0x1112_1314_1516_1718,
+        0x2122_2324_2526_2728,
+        0x3132_3334_3536_3738,
+        0x4142_4344_4546_4748,
+        0x5152_5354_5556_5758,
+        0x6162_6364_6566_6768,
+        0x7172_7374_7576_7778,
+    ]);
+    let mut portable_frand = PortableFrandX8::from_seed(PortableFrandX8Seed::from(frand_seed));
+    let mut specific_frand = SpecificFrandX8::from_seed(SpecificFrandX8Seed::from(frand_seed));
+
+    for _ in 0..3 {
+        assert_eq!(portable_frand.next_u64x8().to_array(), *specific_frand.next_u64x8());
+    }
+
+    let xoshiro_seed = fill_seed_256(&[
+        0x0001_0002_0003_0004,
+        0x0101_0102_0103_0104,
+        0x0201_0202_0203_0204,
+        0x0301_0302_0303_0304,
+        0x0401_0402_0403_0404,
+        0x0501_0502_0503_0504,
+        0x0601_0602_0603_0604,
+        0x0701_0702_0703_0704,
+        0x1001_1002_1003_1004,
+        0x1101_1102_1103_1104,
+        0x1201_1202_1203_1204,
+        0x1301_1302_1303_1304,
+        0x1401_1402_1403_1404,
+        0x1501_1502_1503_1504,
+        0x1601_1602_1603_1604,
+        0x1701_1702_1703_1704,
+        0x2001_2002_2003_2004,
+        0x2101_2102_2103_2104,
+        0x2201_2202_2203_2204,
+        0x2301_2302_2303_2304,
+        0x2401_2402_2403_2404,
+        0x2501_2502_2503_2504,
+        0x2601_2602_2603_2604,
+        0x2701_2702_2703_2704,
+        0x3001_3002_3003_3004,
+        0x3101_3102_3103_3104,
+        0x3201_3202_3203_3204,
+        0x3301_3302_3303_3304,
+        0x3401_3402_3403_3404,
+        0x3501_3502_3503_3504,
+        0x3601_3602_3603_3604,
+        0x3701_3702_3703_3704,
+    ]);
+    let mut portable_xoshiro = PortableXoshiro256PlusX8::from_seed(PortableXoshiro256PlusX8Seed::from(xoshiro_seed));
+    let mut specific_xoshiro = SpecificXoshiro256PlusX8::from_seed(SpecificXoshiro256PlusX8Seed::from(xoshiro_seed));
+
+    for _ in 0..3 {
+        assert_eq!(portable_xoshiro.next_u64x8().to_array(), *specific_xoshiro.next_u64x8());
+    }
+}


### PR DESCRIPTION
Now aligns with the portable impl. Reason this was not caught before is that all the reference seeds and tests were not sensitive to this (i.e. reversing [1,1,1,1] does nothing wrong), so added some explicit tests for this.