### PR TITLE
fix frand implementation

### DIFF
--- a/src/frand.rs
+++ b/src/frand.rs
@@ -1,25 +1,43 @@
-#[cfg(test)]
-pub mod test_support {
-    const INCREMENT: u64 = 12964901029718341801;
-    const MUL_XOR: u64 = 149988720821803190;
+const HASH_MUL: u64 = 4997996261773036203;
 
-    fn repeated_lane_seed<const BYTES: usize>(value: u64, lanes: usize) -> [u8; BYTES] {
-        let mut seed = [0u8; BYTES];
-        let words = BYTES / 8;
+#[must_use]
+pub const fn hash_seed(seed: u64) -> u64 {
+    let seed = (seed ^ (seed >> 32)).wrapping_mul(HASH_MUL);
+    let seed = (seed ^ (seed >> 32)).wrapping_mul(HASH_MUL);
+    seed ^ (seed >> 32)
+}
 
-        assert_eq!(words % lanes, 0);
+#[must_use]
+pub fn repeated_seed_bytes<const BYTES: usize>(seed: u64) -> [u8; BYTES] {
+    let mut bytes = [0u8; BYTES];
 
-        for (index, chunk) in seed.chunks_exact_mut(8).enumerate() {
-            let repeated_index = index / lanes;
-            assert_eq!(repeated_index, 0);
-            chunk.copy_from_slice(&value.to_le_bytes());
-        }
-
-        seed
+    for chunk in bytes.chunks_exact_mut(8) {
+        chunk.copy_from_slice(&seed.to_le_bytes());
     }
 
+    bytes
+}
+
+#[must_use]
+pub fn hash_seed_bytes<const BYTES: usize>(seed: &[u8]) -> [u8; BYTES] {
+    let mut bytes = [0u8; BYTES];
+    assert_eq!(seed.len(), BYTES);
+
+    for (src, dst) in seed.chunks_exact(8).zip(bytes.chunks_exact_mut(8)) {
+        let mut word = [0u8; 8];
+        word.copy_from_slice(src);
+        dst.copy_from_slice(&hash_seed(u64::from_le_bytes(word)).to_le_bytes());
+    }
+
+    bytes
+}
+
+#[cfg(test)]
+pub mod test_support {
+    const REFERENCE_STEPS: usize = if cfg!(miri) { 32 } else { 1024 };
+
     pub fn ref_seed_x4() -> [u8; 32] {
-        repeated_lane_seed::<32>(1, 4)
+        super::repeated_seed_bytes::<32>(1)
     }
 
     #[cfg(any(
@@ -33,23 +51,18 @@ pub mod test_support {
         )
     ))]
     pub fn ref_seed_x8() -> [u8; 64] {
-        repeated_lane_seed::<64>(1, 8)
+        super::repeated_seed_bytes::<64>(1)
     }
 
-    pub struct FrandReference {
+    pub fn assert_seed_from_u64_matches_upstream<const LANES: usize, R>(
         seed: u64,
-    }
+        mut rng: R,
+        mut next: impl FnMut(&mut R) -> [u64; LANES],
+    ) {
+        let mut reference = ::frand::Rand::with_seed(seed);
 
-    impl FrandReference {
-        pub const fn new(seed: u64) -> Self {
-            Self { seed }
-        }
-
-        pub const fn next_u64(&mut self) -> u64 {
-            let value = self.seed.wrapping_add(INCREMENT);
-            self.seed = value;
-            let value = value.wrapping_mul(MUL_XOR ^ value);
-            value ^ (value >> 32)
+        for _ in 0..REFERENCE_STEPS {
+            assert_eq!(next(&mut rng), [reference.r#gen::<u64>(); LANES]);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,6 @@ extern crate alloc;
 extern crate std;
 
 mod biski64;
-#[cfg(test)]
 mod frand;
 
 #[cfg(feature = "portable")]

--- a/src/portable/frandx4.rs
+++ b/src/portable/frandx4.rs
@@ -6,6 +6,8 @@ use core::{
 
 use rand_core::SeedableRng;
 
+use crate::frand::{hash_seed_bytes, repeated_seed_bytes};
+
 use super::{SimdRandX4, read_u64_into_vec};
 
 const INCREMENT: u64x4 = u64x4::from_array([12964901029718341801; 4]);
@@ -74,9 +76,14 @@ impl SeedableRng for FrandX4 {
         const LEN: usize = u64x4::LEN;
         assert!(seed.len() == SIZE * LEN);
 
-        let s = read_u64_into_vec(&seed[..]);
+        let seed = hash_seed_bytes::<32>(&seed[..]);
+        let s = read_u64_into_vec(&seed);
 
         Self { seed: s }
+    }
+
+    fn seed_from_u64(seed: u64) -> Self {
+        Self::from_seed(Self::Seed::from(repeated_seed_bytes::<32>(seed)))
     }
 }
 
@@ -86,5 +93,20 @@ impl SimdRandX4 for FrandX4 {
         self.seed = value;
         let value = value * (MUL_XOR ^ value);
         value ^ (value >> SHIFT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand_core::SeedableRng;
+
+    use super::{FrandX4, SimdRandX4};
+    use crate::frand::test_support::assert_seed_from_u64_matches_upstream;
+
+    #[test]
+    fn seed_from_u64_matches_upstream() {
+        assert_seed_from_u64_matches_upstream::<4, _>(42, FrandX4::seed_from_u64(42), |rng| {
+            rng.next_u64x4().to_array()
+        });
     }
 }

--- a/src/portable/frandx8.rs
+++ b/src/portable/frandx8.rs
@@ -6,6 +6,8 @@ use core::{
 
 use rand_core::SeedableRng;
 
+use crate::frand::{hash_seed_bytes, repeated_seed_bytes};
+
 use super::{SimdRandX8, read_u64_into_vec};
 
 const INCREMENT: u64x8 = u64x8::from_array([12964901029718341801; 8]);
@@ -80,9 +82,14 @@ impl SeedableRng for FrandX8 {
         const LEN: usize = u64x8::LEN;
         assert!(seed.len() == SIZE * LEN);
 
-        let s = read_u64_into_vec(&seed[..]);
+        let seed = hash_seed_bytes::<64>(&seed[..]);
+        let s = read_u64_into_vec(&seed);
 
         Self { seed: s }
+    }
+
+    fn seed_from_u64(seed: u64) -> Self {
+        Self::from_seed(Self::Seed::from(repeated_seed_bytes::<64>(seed)))
     }
 }
 
@@ -92,5 +99,20 @@ impl SimdRandX8 for FrandX8 {
         self.seed = value;
         let value = value * (MUL_XOR ^ value);
         value ^ (value >> SHIFT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand_core::SeedableRng;
+
+    use super::{FrandX8, SimdRandX8};
+    use crate::frand::test_support::assert_seed_from_u64_matches_upstream;
+
+    #[test]
+    fn seed_from_u64_matches_upstream() {
+        assert_seed_from_u64_matches_upstream::<8, _>(42, FrandX8::seed_from_u64(42), |rng| {
+            rng.next_u64x8().to_array()
+        });
     }
 }

--- a/src/specific/avx2/frand.rs
+++ b/src/specific/avx2/frand.rs
@@ -6,6 +6,7 @@ use core::{
 
 use rand_core::SeedableRng;
 
+use crate::frand::{hash_seed_bytes, repeated_seed_bytes};
 use crate::specific::avx2::read_u64_into_vec;
 
 use super::simdrand::*;
@@ -73,9 +74,14 @@ impl SeedableRng for FrandX4 {
         const LEN: usize = 4;
         assert!(seed.len() == SIZE * LEN);
 
-        let s = read_u64_into_vec(&seed[..]);
+        let seed = hash_seed_bytes::<32>(&seed[..]);
+        let s = read_u64_into_vec(&seed);
 
         Self { seed: s }
+    }
+
+    fn seed_from_u64(seed: u64) -> Self {
+        Self::from_seed(Self::Seed::from(repeated_seed_bytes::<32>(seed)))
     }
 }
 
@@ -121,5 +127,18 @@ impl SimdRand for FrandX4 {
 
             _mm256_xor_si256(value, _mm256_srli_epi64::<32>(value))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand_core::SeedableRng;
+
+    use super::{FrandX4, SimdRand};
+    use crate::frand::test_support::assert_seed_from_u64_matches_upstream;
+
+    #[test]
+    fn seed_from_u64_matches_upstream() {
+        assert_seed_from_u64_matches_upstream::<4, _>(42, FrandX4::seed_from_u64(42), |rng| *rng.next_u64x4());
     }
 }

--- a/src/specific/avx512/frand.rs
+++ b/src/specific/avx512/frand.rs
@@ -6,6 +6,7 @@ use core::{
 
 use rand_core::SeedableRng;
 
+use crate::frand::{hash_seed_bytes, repeated_seed_bytes};
 use crate::specific::avx512::read_u64_into_vec;
 
 use super::simdrand::*;
@@ -79,9 +80,14 @@ impl SeedableRng for FrandX8 {
         const LEN: usize = 8;
         assert!(seed.len() == SIZE * LEN);
 
-        let s = read_u64_into_vec(&seed[..]);
+        let seed = hash_seed_bytes::<64>(&seed[..]);
+        let s = read_u64_into_vec(&seed);
 
         Self { seed: s }
+    }
+
+    fn seed_from_u64(seed: u64) -> Self {
+        Self::from_seed(Self::Seed::from(repeated_seed_bytes::<64>(seed)))
     }
 }
 
@@ -100,5 +106,18 @@ impl SimdRand for FrandX8 {
 
             _mm512_xor_si512(value, _mm512_srli_epi64::<32>(value))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand_core::SeedableRng;
+
+    use super::{FrandX8, SimdRand};
+    use crate::frand::test_support::assert_seed_from_u64_matches_upstream;
+
+    #[test]
+    fn seed_from_u64_matches_upstream() {
+        assert_seed_from_u64_matches_upstream::<8, _>(42, FrandX8::seed_from_u64(42), |rng| *rng.next_u64x8());
     }
 }

--- a/src/tests/prngs.rs
+++ b/src/tests/prngs.rs
@@ -1,3 +1,4 @@
+use crate::frand::test_support::ref_seed_x4 as ref_seed_frand_x4;
 #[cfg(any(
     feature = "portable",
     all(
@@ -9,7 +10,6 @@
     )
 ))]
 use crate::frand::test_support::ref_seed_x8 as ref_seed_frand_x8;
-use crate::frand::test_support::{FrandReference, ref_seed_x4 as ref_seed_frand_x4};
 #[cfg(feature = "portable")]
 use crate::portable::{
     Biski64X4, Biski64X4Seed, Biski64X8, Biski64X8Seed, FrandX4, FrandX4Seed, FrandX8, FrandX8Seed, SimdRandX4,
@@ -320,8 +320,8 @@ define_prng_tests!(
     seed = FrandX4Seed,
     ref_seed = ref_seed_frand_x4(),
     reference_seed = 1u64,
-    reference_rng = FrandReference::new,
-    reference_next = |rng: &mut FrandReference| rng.next_u64(),
+    reference_rng = ::frand::Rand::with_seed,
+    reference_next = |rng: &mut ::frand::Rand| rng.r#gen::<u64>(),
     next_u64 = |rng: &mut FrandX4| rng.next_u64x4().to_array(),
     next_f64 = |rng: &mut FrandX4| rng.next_f64x4().to_array()
 );
@@ -334,8 +334,8 @@ define_prng_tests!(
     seed = FrandX8Seed,
     ref_seed = ref_seed_frand_x8(),
     reference_seed = 1u64,
-    reference_rng = FrandReference::new,
-    reference_next = |rng: &mut FrandReference| rng.next_u64(),
+    reference_rng = ::frand::Rand::with_seed,
+    reference_next = |rng: &mut ::frand::Rand| rng.r#gen::<u64>(),
     next_u64 = |rng: &mut FrandX8| rng.next_u64x8().to_array(),
     next_f64 = |rng: &mut FrandX8| rng.next_f64x8().to_array()
 );
@@ -432,8 +432,8 @@ define_prng_tests!(
     seed = SpecificFrandX4Seed,
     ref_seed = ref_seed_frand_x4(),
     reference_seed = 1u64,
-    reference_rng = FrandReference::new,
-    reference_next = |rng: &mut FrandReference| rng.next_u64(),
+    reference_rng = ::frand::Rand::with_seed,
+    reference_next = |rng: &mut ::frand::Rand| rng.r#gen::<u64>(),
     next_u64 = |rng: &mut SpecificFrandX4| *rng.next_u64x4(),
     next_f64 = |rng: &mut SpecificFrandX4| *rng.next_f64x4()
 );
@@ -494,8 +494,8 @@ define_prng_tests!(
     seed = SpecificFrandX8Seed,
     ref_seed = ref_seed_frand_x8(),
     reference_seed = 1u64,
-    reference_rng = FrandReference::new,
-    reference_next = |rng: &mut FrandReference| rng.next_u64(),
+    reference_rng = ::frand::Rand::with_seed,
+    reference_next = |rng: &mut ::frand::Rand| rng.r#gen::<u64>(),
     next_u64 = |rng: &mut SpecificFrandX8| *rng.next_u64x8(),
     next_f64 = |rng: &mut SpecificFrandX8| *rng.next_f64x8()
 );


### PR DESCRIPTION
frand is doing a hash on the seed values before construction. I feel it is better to align with that, let algos implemented here map 1:1 to the reference implementations